### PR TITLE
Fix showcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ showcase/war/WEB-INF/deploy
 showcase/war/WEB-INF/classes
 showcase/war/app
 showcase/war/dmr_gwt
-showcase/war/App.html

--- a/showcase/src/main/java/org/jboss/as/console/App.gwt.xml
+++ b/showcase/src/main/java/org/jboss/as/console/App.gwt.xml
@@ -25,7 +25,7 @@
     <inherits name="com.google.gwt.editor.Editor"/>
     <inherits name="com.google.gwt.i18n.I18N"/>
 
-    <inherits name="org.jboss.as.console.Framework_RH"/>
+    <inherits name="org.jboss.ballroom.Framework_RH"/>
 
 
     <define-configuration-property name="gin.ginjector" is-multi-valued="false" />

--- a/showcase/src/main/java/org/jboss/as/console/client/layout/MainLayoutPresenter.java
+++ b/showcase/src/main/java/org/jboss/as/console/client/layout/MainLayoutPresenter.java
@@ -32,8 +32,9 @@ import com.gwtplatform.mvp.client.proxy.PlaceRequest;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 import com.gwtplatform.mvp.client.proxy.RevealRootLayoutContentEvent;
+
 import org.jboss.as.console.client.NameTokens;
-import org.jboss.as.console.client.util.LoadingOverlay;
+import org.jboss.ballroom.client.util.LoadingOverlay;
 
 /**
  * @author Heiko Braun

--- a/showcase/war/App.html
+++ b/showcase/war/App.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+    <title>JBoss Management</title>
+    <!-- proper charset -->
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+
+    <!-- default locale -->
+    <!--meta name="gwt:property" content="locale=de"-->
+
+    <script type="text/javascript" language="javascript" src="app/app.nocache.js"></script>
+
+</head>
+<body>
+
+<!-- history iframe required on IE -->
+<iframe src="javascript:''" id="__gwt_historyFrame" style="width:0px;height:0px;border:0px"></iframe>
+
+<!-- pre load images-->
+<div style="visibility:hidden"><img src="images/loading_lite.gif"/></div>
+</body >
+</html>

--- a/showcase/war/index.html
+++ b/showcase/war/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+
+    <!-- Forward to the GWT Application -->
+    <meta http-equiv="REFRESH" content="0;url=App.html">
+
+</HEAD>
+<body>
+
+</body>
+</HTML>


### PR DESCRIPTION
- Fixes incorrect capitalization of Java Class MainLayoutPresenter
- Fixes package name of LoadingOverlay class in MainlayoutPresenter
- Fixes parent module name in App.gwt.xml
- Add App.html because that one is missing and causes the demo startup to
  fail (at least on Mac OSX)
