### PR TITLE
Form changes

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/ComboBoxItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/ComboBoxItem.java
@@ -159,4 +159,8 @@ public class ComboBoxItem extends FormItem<String> {
         else
             comboBox.clearSelection();
     }
+    
+    public void addValueChangeHandler(ValueChangeHandler<String> handler) {
+        this.comboBox.addValueChangeHandler(handler);
+    }
 }


### PR DESCRIPTION
Allow a FormItem to have an AutoBean or List of AutoBeans as its value.  Before, FormItems could only wrap a String or List<String>.  Other return values would break the Form.  So now we can make our own FormItems that wrap AutoBeans.

Also, allow registration of a ValueChangeHandler on a ComboBoxItem
