### PR TITLE
Make resetMetaData public in FormItem

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/CheckBoxItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/CheckBoxItem.java
@@ -45,7 +45,7 @@ public class CheckBoxItem extends FormItem<Boolean> {
     }
 
     @Override
-    protected void resetMetaData() {
+    public void resetMetaData() {
         super.resetMetaData();
         isUndefined = false; // implicitly defined
         checkBox.setValue(false);

--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/FormItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/FormItem.java
@@ -102,7 +102,7 @@ public abstract class FormItem<T> implements InputElement<T> {
         isUndefined = undefined;
     }
 
-    protected void resetMetaData() {
+    public void resetMetaData() {
         isModified = false;
         isUndefined = true;
         setErroneous(false);

--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/TextAreaItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/TextAreaItem.java
@@ -59,7 +59,7 @@ public class TextAreaItem extends FormItem<String> {
     }
 
     @Override
-    protected void resetMetaData() {
+    public void resetMetaData() {
         super.resetMetaData();
         textArea.setValue(null);
     }


### PR DESCRIPTION
Make resetMetaData public instead of protected.  This allows a FormItem to be wrapped.  If this is not acceptable we could move the wrapping class into ballroom or add extra functionality to the FormItem class.  But if letting resetMetaData be public is not going to cause problems then this is probably a good first step.
